### PR TITLE
#1912 Add docs for `Validator.destroy()` on the webpage.

### DIFF
--- a/entries/Validator.destroy.xml
+++ b/entries/Validator.destroy.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="../entries2html.xsl" ?>
+<entry type="method" name="Validator.destroy">
+	<title>Validator.destroy()</title>
+	<signature>
+	</signature>
+	<desc>Destroys this instance of validator freeing up resources and unregistering events.</desc>
+	<longdesc>This is only useful, when you need to clean up after the validator in a Single Page Application.</longdesc>
+	<example>
+		<desc>Destroying an instance of validator.</desc>
+		<code><![CDATA[
+/*
+ * On SPA page start.
+ */
+var validator = $( "#myform" ).validate();
+
+/*
+ * Just before SPA page's navigation away.
+ */
+validator.destroy();
+
+/*
+ * After this point the #myForm form is back to its original boring state.
+ */
+]]></code>
+	</example>
+	<category slug="validator"/>
+</entry>

--- a/pages/documentation.md
+++ b/pages/documentation.md
@@ -95,6 +95,7 @@ The validate method returns a Validator object that has a few public methods tha
 * [`Validator.resetForm()` - Resets the controlled form.](/Validator.resetForm)
 * [`Validator.showErrors()` - Show the specified messages.](/Validator.showErrors)
 * [`Validator.numberOfInvalids()` - Returns the number of invalid fields.](/Validator.numberOfInvalids)
+* [`Validator.destroy()` - Destroys this instance of validator.](/Validator.destroy)
 
 There are a few static methods on the validator object:
 


### PR DESCRIPTION
Fixes [#1912](https://github.com/jzaefferer/jquery-validation/issues/1912)