### PR TITLE
Update onclick in validate.xml to reflect select elements

### DIFF
--- a/entries/validate.xml
+++ b/entries/validate.xml
@@ -272,10 +272,10 @@
 			</property>
 			<property name="onclick">
 				<desc>
-					Validate checkboxes and radio buttons on click. Set to false to disable.
+					Validate checkboxes, radio buttons, and select elements on click. Set to false to disable.
 					<p>Set to a Function to decide for yourself when to run validation.</p>
 					<p>A boolean true is not a valid value.</p>
-					<p><strong>Example</strong>: Disables onclick validation of checkboxes and radio buttons.</p>
+					<p><strong>Example</strong>: Disables onclick validation of checkboxes, radio buttons, and select elements.</p>
 					<pre><code>
 					$("#myform").validate({
 						onclick: false


### PR DESCRIPTION
When answering a question on StackOverflow about a broken `select` element, the OP had this option set to `false`.  The `select` element was then only being validated on focusout and submit.  Selecting items in the select had no effect on the validation message of this element until moving focus away.   

Removing this option, since it cannot be set to `true`, fixed the issue.  Therefore, the documentation is incomplete.  This option effects validation of `select` elements as well as radio and checkbox.

Comment out the `onclick` line in the demo to see the difference:

[DEMO](https://jsfiddle.net/ps56w2fn/)