### PR TITLE
Entries: Fix `submitHandler`'s arguments description

### DIFF
--- a/entries/validate.xml
+++ b/entries/validate.xml
@@ -25,7 +25,7 @@
 			</property>
 			<property name="submitHandler" default="native form submit">
 				<desc>
-					Callback for handling the actual submit when the form is valid. Gets the form as the only argument. Replaces the default submit. The right place to <a href="http://www.malsup.com/jquery/form/#api">submit a form via Ajax</a> after it is validated.
+					Callback for handling the actual submit when the form is valid. Gets the form and the submit event as the only arguments. Replaces the default submit. The right place to <a href="http://www.malsup.com/jquery/form/#api">submit a form via Ajax</a> after it is validated.
 					<p><strong>Example</strong>: Submits the form via Ajax when valid.</p>
 					<pre><code>
 					$("#myform").validate({


### PR DESCRIPTION
A follow-up of #26